### PR TITLE
spike protected adstatus

### DIFF
--- a/api-gateway/package-lock.json
+++ b/api-gateway/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "api-gateway",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -28,6 +29,7 @@
         "passport-jwt": "^4.0.0",
         "path": "^0.12.7",
         "save": "^2.4.0",
+        "spike-auth-middleware": "^1.1.6",
         "swagger-autogen": "^2.10.2",
         "swagger-node-express": "^1.2.3",
         "swagger-ui-express": "^4.1.6",
@@ -1869,6 +1871,11 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+    },
+    "node_modules/fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -4081,6 +4088,16 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
       "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA=="
+    },
+    "node_modules/spike-auth-middleware": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/spike-auth-middleware/-/spike-auth-middleware-1.1.6.tgz",
+      "integrity": "sha512-2EA7ihXxIOj54HQrU3Cn8DJW3pZbd5gcq42J5P+Wsoc7Jv2JEJTSFdEijpNQSRXjB72QKu4rQmTYeZLJ+1T1Vw==",
+      "dependencies": {
+        "fs": "0.0.1-security",
+        "passport": "^0.4.1",
+        "passport-jwt": "^4.0.0"
+      }
     },
     "node_modules/split": {
       "version": "1.0.1",
@@ -6908,6 +6925,11 @@
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
+    },
     "fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -8661,6 +8683,16 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
       "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA=="
+    },
+    "spike-auth-middleware": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/spike-auth-middleware/-/spike-auth-middleware-1.1.6.tgz",
+      "integrity": "sha512-2EA7ihXxIOj54HQrU3Cn8DJW3pZbd5gcq42J5P+Wsoc7Jv2JEJTSFdEijpNQSRXjB72QKu4rQmTYeZLJ+1T1Vw==",
+      "requires": {
+        "fs": "0.0.1-security",
+        "passport": "^0.4.1",
+        "passport-jwt": "^4.0.0"
+      }
     },
     "split": {
       "version": "1.0.1",

--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -34,6 +34,7 @@
     "passport-jwt": "^4.0.0",
     "path": "^0.12.7",
     "save": "^2.4.0",
+    "spike-auth-middleware": "^1.1.6",
     "swagger-autogen": "^2.10.2",
     "swagger-node-express": "^1.2.3",
     "swagger-ui-express": "^4.1.6",

--- a/api-gateway/src/approver/approver.controller.ts
+++ b/api-gateway/src/approver/approver.controller.ts
@@ -127,6 +127,7 @@ export default class ApproverController {
       domainUsers: entity.digitalIdentities.map(
         (digitalIdentity) => digitalIdentity.uniqueId
       ),
+      directGroup: entity.directGroup || ""
     };
 
     try {
@@ -183,6 +184,7 @@ export default class ApproverController {
             akaUnit: request.additionalParams?.akaUnit || '',
             displayName: request.additionalParams?.displayName || '',
             domainUsers: request.additionalParams?.domainUsers || [],
+            directGroup: request.additionalParams?.directGroup || ""
           });
           await RequestsService.updateRequest({
             id: request.id,

--- a/api-gateway/src/config.ts
+++ b/api-gateway/src/config.ts
@@ -31,4 +31,9 @@ export const config = {
       .asString(),
     required: env.get('GATEWAY_AUTHENTICATION_REQUIRED').default(0).asBool(),
   },
+  spike: {
+    audienceId: env.get('GATEWAY_SPIKE_AUDIENCE_ID').default('audience').asString(),
+    publicKeyPath: env.get('GATEWAY_SPIKE_PUBLIC_KEY_FULL_PATH').default('publickey.pem').asString(),
+    writeScopeName: env.get('GATEWAY_WRITE_SCOPR_NAME').default('write').asString()
+  }
 };

--- a/api-gateway/src/utils/spike.ts
+++ b/api-gateway/src/utils/spike.ts
@@ -1,0 +1,13 @@
+import { config } from '../config';
+
+const { getSpikeAuthMiddleWare } = require('spike-auth-middleware');
+
+const writeMiddleWareConfiguration = {
+  audience: config.spike.audienceId,
+  allowedScopes: config.spike.writeScopeName,
+  pathToPublicKey: config.spike.publicKeyPath
+};
+
+export const validateSpikeWriteScope = getSpikeAuthMiddleWare(
+  writeMiddleWareConfiguration
+);


### PR DESCRIPTION
supports Spike protected adstatus and refactors auth a tiny bit.
NOTICE: api-gateway requires "kartoffel public key path" defined in: 
`env.get('GATEWAY_SPIKE_PUBLIC_KEY_FULL_PATH')` and defaulted to: `'publickey.pem'` at ./utils/